### PR TITLE
use standard linter

### DIFF
--- a/docs/demo.js
+++ b/docs/demo.js
@@ -1,12 +1,12 @@
 // Delete :+1: comments
-const singleEmoji = /^\W*(:[\w-+]+:|[\uE000-\uF8FF]|\uD83C[\uDF00-\uDFFF]|\uD83D[\uDC00-\uDDFF])\W*$/g;
+const singleEmoji = /^\W*(:[\w-+]+:|[\uE000-\uF8FF]|\uD83C[\uDF00-\uDFFF]|\uD83D[\uDC00-\uDDFF])\W*$/g
 on('issue_comment.created')
   .filter(event => event.payload.comment.body.match(singleEmoji))
-  .deleteComment();
+  .deleteComment()
 
-function isDeleted(event) {
+function isDeleted (event) {
   return event.payload.action === 'deleted' &&
-  event.payload.sender.type !== 'Bot';
+  event.payload.sender.type !== 'Bot'
 }
 
 // restore deleted comments but the one deleted by PRobot
@@ -16,4 +16,4 @@ on('issue_comment', 'commit_comment', 'pull_request_review_comment')
 Deleted comment from @{{ comment.user.login }} at {{ comment.updated_at }}
 ---
 {{ comment.body }}
-`);
+`)

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
-const Configuration = require('./lib/configuration');
-const Context = require('./lib/context');
+const Configuration = require('./lib/configuration')
+const Context = require('./lib/context')
 
 module.exports = robot => {
-  robot.on('*', receive);
+  robot.on('*', receive)
 
-  async function receive(event) {
+  async function receive (event) {
     if (event.payload.repository) {
-      const github = await robot.auth(event.payload.installation.id);
-      const context = new Context(github, event);
-      const config = await Configuration.load(context, '.probot.js');
-      return config.execute();
+      const github = await robot.auth(event.payload.installation.id)
+      const context = new Context(github, event)
+      const config = await Configuration.load(context, '.probot.js')
+      return config.execute()
     }
   }
-};
+}

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,59 +1,59 @@
-const Sandbox = require('./sandbox');
-const Workflow = require('./workflow');
-const url = require('./util/github-url');
+const Sandbox = require('./sandbox')
+const Workflow = require('./workflow')
+const url = require('./util/github-url')
 
 module.exports = class Configuration {
-  static load(context, path, source) {
-    const options = context.toRepo(url(path, source));
+  static load (context, path, source) {
+    const options = context.toRepo(url(path, source))
     return context.github.repos.getContent(options).then(data => {
-      const config = new Configuration(context, options);
-      return config.parse(new Buffer(data.content, 'base64').toString());
-    });
+      const config = new Configuration(context, options)
+      return config.parse(Buffer.from(data.content, 'base64').toString())
+    })
   }
 
-  constructor(context, source) {
-    this.context = context;
-    this.source = source || {};
-    this.workflows = [];
+  constructor (context, source) {
+    this.context = context
+    this.source = source || {}
+    this.workflows = []
 
     this.api = {
       on: this.on.bind(this),
       include: this.include.bind(this),
       contents: this.contents.bind(this)
-    };
+    }
   }
 
-  on(...events) {
-    const workflow = new Workflow();
-    this.workflows.push(workflow);
-    return workflow.api.on(...events);
+  on (...events) {
+    const workflow = new Workflow()
+    this.workflows.push(workflow)
+    return workflow.api.on(...events)
   }
 
-  include(path) {
-    const load = Configuration.load(this.context, path, this.source);
+  include (path) {
+    const load = Configuration.load(this.context, path, this.source)
 
     this.workflows.push({
-      execute() {
-        return load.then(config => config.execute(this.context));
+      execute () {
+        return load.then(config => config.execute(this.context))
       }
-    });
+    })
 
-    return undefined;
+    return undefined
   }
 
-  contents(path) {
-    const options = this.context.toRepo(url(path, this.source));
+  contents (path) {
+    const options = this.context.toRepo(url(path, this.source))
     return this.context.github.repos.getContent(options).then(data => {
-      return new Buffer(data.content, 'base64').toString();
-    });
+      return Buffer.from(data.content, 'base64').toString()
+    })
   }
 
-  parse(content) {
-    new Sandbox(content).execute(this.api);
-    return this;
+  parse (content) {
+    new Sandbox(content).execute(this.api)
+    return this
   }
 
-  execute() {
-    return Promise.all(this.workflows.map(w => w.execute(this.context)));
+  execute () {
+    return Promise.all(this.workflows.map(w => w.execute(this.context)))
   }
-};
+}

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,26 +1,26 @@
 module.exports = class Context {
-  constructor(github, event) {
-    this.github = github;
-    this.event = event;
-    this.payload = event.payload;
+  constructor (github, event) {
+    this.github = github
+    this.event = event
+    this.payload = event.payload
   }
 
-  halt() {
-    return Promise.reject(new Error('halted'));
+  halt () {
+    return Promise.reject(new Error('halted'))
   }
 
-  toRepo(object) {
-    const repo = this.payload.repository;
+  toRepo (object) {
+    const repo = this.payload.repository
 
     return Object.assign({
       owner: repo.owner.login || repo.owner.name,
       repo: repo.name
-    }, object);
+    }, object)
   }
 
-  toIssue(object) {
+  toIssue (object) {
     return Object.assign({
       number: (this.payload.issue || this.payload.pull_request || this.payload).number
-    }, this.toRepo(), object);
+    }, this.toRepo(), object)
   }
-};
+}

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,7 +1,7 @@
 module.exports = class Plugin {
-  get api() {
-    const properties = Object.getOwnPropertyNames(this.constructor.prototype);
-    properties.splice(properties.indexOf('constructor'), 1);
-    return properties;
+  get api () {
+    const properties = Object.getOwnPropertyNames(this.constructor.prototype)
+    properties.splice(properties.indexOf('constructor'), 1)
+    return properties
   }
-};
+}

--- a/lib/plugins/filter.js
+++ b/lib/plugins/filter.js
@@ -1,22 +1,22 @@
-const Plugin = require('../plugin');
+const Plugin = require('../plugin')
 
 module.exports = class Filter extends Plugin {
-  filter(context, fn) {
-    const result = fn(context.event, context);
-    return result === false ? context.halt() : result;
+  filter (context, fn) {
+    const result = fn(context.event, context)
+    return result === false ? context.halt() : result
   }
 
-  then(context, fn) {
-    return fn(context.event, context);
+  then (context, fn) {
+    return fn(context.event, context)
   }
 
-  on(context, ...events) {
-    const event = context.event;
+  on (context, ...events) {
+    const event = context.event
     const res = events.find(e => {
-      const [name, action] = e.split('.');
-      return name === event.event && (!action || action === event.payload.action);
-    });
+      const [name, action] = e.split('.')
+      return name === event.event && (!action || action === event.payload.action)
+    })
 
-    return res ? Promise.resolve(res) : context.halt();
+    return res ? Promise.resolve(res) : context.halt()
   }
-};
+}

--- a/lib/plugins/issues.js
+++ b/lib/plugins/issues.js
@@ -1,66 +1,66 @@
-const handlebars = require('handlebars');
-const Plugin = require('../plugin');
+const handlebars = require('handlebars')
+const Plugin = require('../plugin')
 
 module.exports = class Issues extends Plugin {
-  comment(context, content) {
-    const template = handlebars.compile(content)(context.payload);
-    return context.github.issues.createComment(context.toIssue({body: template}));
+  comment (context, content) {
+    const template = handlebars.compile(content)(context.payload)
+    return context.github.issues.createComment(context.toIssue({body: template}))
   }
 
-  assign(context, ...assignees) {
-    return context.github.issues.addAssigneesToIssue(context.toIssue({assignees}));
+  assign (context, ...assignees) {
+    return context.github.issues.addAssigneesToIssue(context.toIssue({assignees}))
   }
 
-  unassign(context, ...assignees) {
-    return context.github.issues.removeAssigneesFromIssue(context.toIssue({body: {assignees}}));
+  unassign (context, ...assignees) {
+    return context.github.issues.removeAssigneesFromIssue(context.toIssue({body: {assignees}}))
   }
 
-  label(context, ...labels) {
-    return context.github.issues.addLabels(context.toIssue({body: labels}));
+  label (context, ...labels) {
+    return context.github.issues.addLabels(context.toIssue({body: labels}))
   }
 
-  unlabel(context, ...labels) {
+  unlabel (context, ...labels) {
     return labels.map(label => {
       return context.github.issues.removeLabel(
         context.toIssue({name: label})
-      );
-    });
+      )
+    })
   }
 
-  lock(context) {
-    return context.github.issues.lock(context.toIssue({}));
+  lock (context) {
+    return context.github.issues.lock(context.toIssue({}))
   }
 
-  unlock(context) {
-    return context.github.issues.unlock(context.toIssue({}));
+  unlock (context) {
+    return context.github.issues.unlock(context.toIssue({}))
   }
 
-  open(context) {
-    return context.github.issues.edit(context.toIssue({state: 'open'}));
+  open (context) {
+    return context.github.issues.edit(context.toIssue({state: 'open'}))
   }
 
-  close(context) {
-    return context.github.issues.edit(context.toIssue({state: 'closed'}));
+  close (context) {
+    return context.github.issues.edit(context.toIssue({state: 'closed'}))
   }
 
-  deleteComment(context) {
-    const comment = context.payload.comment;
-    const github = context.github;
+  deleteComment (context) {
+    const comment = context.payload.comment
+    const github = context.github
 
     const deleteFunction =
       (comment.pull_request_review_id && github.pullRequests.deleteComment) ||
       (comment.commit_id && github.repos.deleteCommitComment) ||
-      github.issues.deleteComment;
+      github.issues.deleteComment
 
-    return deleteFunction(context.toRepo({id: comment.id}));
+    return deleteFunction(context.toRepo({id: comment.id}))
   }
 
-  createIssue(context, content) {
+  createIssue (context, content) {
     return Promise.resolve(content.body).then(body => {
-      const titleTemplate = handlebars.compile(content.title)(context.payload);
-      const bodyTemplate = handlebars.compile(body)(context.payload);
+      const titleTemplate = handlebars.compile(content.title)(context.payload)
+      const bodyTemplate = handlebars.compile(body)(context.payload)
 
-      return context.github.issues.create(context.toRepo({title: titleTemplate, body: bodyTemplate, assignees: content.assignees, labels: content.labels}));
-    });
+      return context.github.issues.create(context.toRepo({title: titleTemplate, body: bodyTemplate, assignees: content.assignees, labels: content.labels}))
+    })
   }
-};
+}

--- a/lib/plugins/projects.js
+++ b/lib/plugins/projects.js
@@ -1,24 +1,23 @@
-const Plugin = require('../plugin');
+const Plugin = require('../plugin')
 
 module.exports = class Projects extends Plugin {
-
   // creates a card, based on an issue, and adds to a column
   // accepts a content object in the format {project: 'ProjectName', column: 'ColumnName'}
-  createCard(context, content) {
+  createCard (context, content) {
     return Promise.resolve().then(() => {
       // get all projects for repo
       getRepoProjects(context, content)
         // then get the projectID for desired project
         .then(response => {
-          return getID(response, content.project);
+          return getID(response, content.project)
         })
         // then get the columns for that project
         .then(projectID => {
-          return getProjectColumns(context, projectID);
+          return getProjectColumns(context, projectID)
         })
         // then get the columnID for the desired column
         .then(projectColumns => {
-          return getID(projectColumns, content.column);
+          return getID(projectColumns, content.column)
         })
         // then create the card
         .then(columnID => {
@@ -26,38 +25,36 @@ module.exports = class Projects extends Plugin {
             column_id: columnID,
             content_id: context.payload.issue.id,
             content_type: 'Issue'
-          });
-        });
-      return;
-    });
+          })
+        })
+    })
   }
-
-};
+}
 
 // Helper functions below
 
 // function to get all repository projects
-function getRepoProjects(context) {
+function getRepoProjects (context) {
   return context.github.projects.getRepoProjects({
     owner: context.payload.repository.owner.login,
     repo: context.payload.repository.name
-  });
+  })
 }
 
 // function to return an ID based on a name
 // looks through objects to find the object whose value for the 'name' key
 // matches the 'name' parameter passed to the function and returns the ID of the object
-function getID(objs, name) {
+function getID (objs, name) {
   for (let i = 0; i < objs.length; i++) {
     if (objs[i].name === name) {
-      return objs[i].id;
+      return objs[i].id
     }
   }
 }
 
 // function to get all columns in a project
-function getProjectColumns(context, project_id) {
+function getProjectColumns (context, projectId) {
   return context.github.projects.getProjectColumns({
-    project_id
-  });
+    projectId
+  })
 }

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1,15 +1,15 @@
-const vm = require('vm');
+const vm = require('vm')
 
 class Sandbox {
-  constructor(content) {
-    this.content = content;
+  constructor (content) {
+    this.content = content
   }
 
-  execute(api) {
-    vm.createContext(api);
-    vm.runInContext(this.content, api);
-    return this.workflows;
+  execute (api) {
+    vm.createContext(api)
+    vm.runInContext(this.content, api)
+    return this.workflows
   }
 }
 
-module.exports = Sandbox;
+module.exports = Sandbox

--- a/lib/util/github-url.js
+++ b/lib/util/github-url.js
@@ -1,7 +1,7 @@
-const REGEX = /^(?:([\w-]+)\/([\w-]+):)?([^#]*)(?:#(.*))?$/;
+const REGEX = /^(?:([\w-]+)\/([\w-]+):)?([^#]*)(?:#(.*))?$/
 
 // Parses paths in the form of `owner/repo:path/to/file#ref`
 module.exports = function (url, source) {
-  const [, owner, repo, path, ref] = url.match(REGEX);
-  return Object.assign({}, source, {path}, owner && {owner, repo}, ref && {ref});
-};
+  const [, owner, repo, path, ref] = url.match(REGEX)
+  return Object.assign({}, source, {path}, owner && {owner, repo}, ref && {ref})
+}

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -1,43 +1,43 @@
-const Filter = require('./plugins/filter');
-const Issues = require('./plugins/issues');
-const Projects = require('./plugins/projects');
+const Filter = require('./plugins/filter')
+const Issues = require('./plugins/issues')
+const Projects = require('./plugins/projects')
 
 const defaultPlugins = [
   new Filter(),
   new Issues(),
   new Projects()
-];
+]
 
 module.exports = class Workflow {
-  constructor(plugins = defaultPlugins) {
-    this.stack = [];
-    this.api = {};
+  constructor (plugins = defaultPlugins) {
+    this.stack = []
+    this.api = {}
 
     // Define a new function in the API for each plugin method
     for (const plugin of plugins) {
       for (const method of plugin.api) {
-        this.api[method] = this.proxy(plugin[method]).bind(this);
+        this.api[method] = this.proxy(plugin[method]).bind(this)
       }
     }
   }
 
-  proxy(fn) {
+  proxy (fn) {
     return (...args) => {
       // Push new function on the stack that calls the plugin method with a context.
       this.stack.push(context => {
         // Resolve all args before passing to plugin
-        return Promise.all(args).then(args => fn(context, ...args));
-      });
+        return Promise.all(args).then(args => fn(context, ...args))
+      })
 
       // Return the API to allow methods to be chained.
-      return this.api;
-    };
+      return this.api
+    }
   }
 
-  execute(context) {
+  execute (context) {
     // Reduce the stack to a chain of promises, each called with the given context
     return this.stack.reduce((promise, func) => {
-      return promise.then(func.bind(func, context));
-    }, Promise.resolve());
+      return promise.then(func.bind(func, context))
+    }, Promise.resolve())
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/probot/workflow",
   "scripts": {
     "start": "probot run ./index.js",
-    "test": "mocha && xo"
+    "test": "mocha && standard"
   },
   "dependencies": {
     "handlebars": "^4.0.6",
@@ -17,20 +17,13 @@
     "npm": ">= 4.0.0"
   },
   "devDependencies": {
+    "eslint-plugin-markdown": "^1.0.0-beta.6",
     "expect": "^1.20.2",
     "mocha": "^3.2.0",
-    "xo": "^0.17.1"
+    "standard": "^10.0.3"
   },
-  "xo": {
-    "esnext": true,
-    "space": true,
-    "rules": {
-      "camelcase": 1,
-      "no-else-return": 0,
-      "key-spacing": 0
-    },
-    "envs": [
-      "node",
+  "standard": {
+    "env": [
       "mocha"
     ],
     "globals": [
@@ -38,19 +31,8 @@
       "include",
       "contents"
     ],
-    "overrides": [
-      {
-        "files": "test/**/*.js",
-        "rules": {
-          "max-nested-callbacks": "off"
-        }
-      },
-      {
-        "files": "lib/plugins/projects.js",
-        "rules": {
-          "camelcase": "off"
-        }
-      }
+    "plugins": [
+      "markdown"
     ]
   }
 }

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -1,57 +1,57 @@
-const expect = require('expect');
-const Configuration = require('../lib/configuration');
-const Context = require('../lib/context');
-const content = require('./fixtures/content/probot.json');
-const payload = require('./fixtures/webhook/comment.created');
+const expect = require('expect')
+const Configuration = require('../lib/configuration')
+const Context = require('../lib/context')
+const content = require('./fixtures/content/probot.json')
+const payload = require('./fixtures/webhook/comment.created')
 
-const createSpy = expect.createSpy;
+const createSpy = expect.createSpy
 
-content.content = new Buffer(`
+content.content = Buffer.from(`
   on("issues.opened")
     .comment("Hello World!")
     .assign("bkeepers");
 
   on("issues.closed")
     .unassign("bkeepers");
-`).toString('base64');
+`).toString('base64')
 
 describe('Configuration', () => {
   describe('include', () => {
-    let github;
-    let context;
-    let config;
+    let github
+    let context
+    let config
 
     beforeEach(() => {
       github = {
         repos: {
           getContent: createSpy().andReturn(Promise.resolve(content))
         }
-      };
-      context = new Context(github, {payload});
-      config = new Configuration(context);
-    });
+      }
+      context = new Context(github, {payload})
+      config = new Configuration(context)
+    })
 
     it('includes from the repo', () => {
-      config.include('foo.js');
+      config.include('foo.js')
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         path: 'foo.js'
-      });
-    });
+      })
+    })
 
     it('returns undefined', () => {
-      expect(config.include('foo.js')).toBe(undefined);
-    });
+      expect(config.include('foo.js')).toBe(undefined)
+    })
 
     it('includes from another repository', () => {
-      config.include('atom/configs:foo.js#branch');
+      config.include('atom/configs:foo.js#branch')
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'atom',
         repo: 'configs',
         path: 'foo.js',
         ref: 'branch'
-      });
-    });
-  });
-});
+      })
+    })
+  })
+})

--- a/test/context.js
+++ b/test/context.js
@@ -1,10 +1,10 @@
-const expect = require('expect');
-const Context = require('../lib/context');
+const expect = require('expect')
+const Context = require('../lib/context')
 
 describe('Context', () => {
-  const github = {};
-  let event;
-  let context;
+  const github = {}
+  let event
+  let context
 
   beforeEach(() => {
     event = {
@@ -15,52 +15,52 @@ describe('Context', () => {
         },
         issue: {number: 4}
       }
-    };
-    context = new Context(github, event);
-  });
+    }
+    context = new Context(github, event)
+  })
 
   describe('toRepo', () => {
     it('returns attributes from repository payload', () => {
-      expect(context.toRepo()).toEqual({owner: 'bkeepers', repo:'probot'});
-    });
+      expect(context.toRepo()).toEqual({owner: 'bkeepers', repo: 'probot'})
+    })
 
     it('merges attributes', () => {
       expect(context.toRepo({foo: 1, bar: 2})).toEqual({
-        owner: 'bkeepers', repo:'probot', foo: 1, bar: 2
-      });
-    });
+        owner: 'bkeepers', repo: 'probot', foo: 1, bar: 2
+      })
+    })
 
     it('overrides repo attributes', () => {
       expect(context.toRepo({owner: 'muahaha'})).toEqual({
-        owner: 'muahaha', repo:'probot'
-      });
-    });
+        owner: 'muahaha', repo: 'probot'
+      })
+    })
 
     // The `repository` object on the push event has a different format than the other events
     // https://developer.github.com/v3/activity/events/types/#pushevent
     it('properly handles the push event', () => {
-      event.payload = require('./fixtures/webhook/push');
+      event.payload = require('./fixtures/webhook/push')
 
-      context = new Context(github, event);
-      expect(context.toRepo()).toEqual({owner: 'bkeepers-inc', repo:'test'});
-    });
-  });
+      context = new Context(github, event)
+      expect(context.toRepo()).toEqual({owner: 'bkeepers-inc', repo: 'test'})
+    })
+  })
 
   describe('toIssue', () => {
     it('returns attributes from repository payload', () => {
-      expect(context.toIssue()).toEqual({owner: 'bkeepers', repo:'probot', number: 4});
-    });
+      expect(context.toIssue()).toEqual({owner: 'bkeepers', repo: 'probot', number: 4})
+    })
 
     it('merges attributes', () => {
       expect(context.toIssue({foo: 1, bar: 2})).toEqual({
-        owner: 'bkeepers', repo:'probot', number: 4, foo: 1, bar: 2
-      });
-    });
+        owner: 'bkeepers', repo: 'probot', number: 4, foo: 1, bar: 2
+      })
+    })
 
     it('overrides repo attributes', () => {
       expect(context.toIssue({owner: 'muahaha', number: 5})).toEqual({
-        owner: 'muahaha', repo:'probot', number: 5
-      });
-    });
-  });
-});
+        owner: 'muahaha', repo: 'probot', number: 5
+      })
+    })
+  })
+})

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,14 +1,14 @@
-const expect = require('expect');
-const Configuration = require('../lib/configuration');
-const Context = require('../lib/context');
-const payload = require('./fixtures/webhook/comment.created.json');
+const expect = require('expect')
+const Configuration = require('../lib/configuration')
+const Context = require('../lib/context')
+const payload = require('./fixtures/webhook/comment.created.json')
 
-const createSpy = expect.createSpy;
+const createSpy = expect.createSpy
 
 describe('integration', () => {
-  const event = {event: 'issues', payload};
-  let context;
-  let github;
+  const event = {event: 'issues', payload}
+  let context
+  let github
 
   beforeEach(() => {
     github = {
@@ -19,117 +19,117 @@ describe('integration', () => {
       repos: {
         getContent: createSpy()
       }
-    };
+    }
 
-    context = new Context(github, event);
-  });
+    context = new Context(github, event)
+  })
 
-  function configure(content) {
-    return new Configuration(context).parse(content);
+  function configure (content) {
+    return new Configuration(context).parse(content)
   }
 
   describe('reply to new issue with a comment', () => {
     it('posts a coment', () => {
-      const config = configure('on("issues").comment("Hello World!")');
+      const config = configure('on("issues").comment("Hello World!")')
       return config.execute(context).then(() => {
-        expect(github.issues.createComment).toHaveBeenCalled();
-      });
-    });
-  });
+        expect(github.issues.createComment).toHaveBeenCalled()
+      })
+    })
+  })
 
   describe('on an event with a different action', () => {
     it('does not perform behavior', () => {
-      const config = configure('on("issues.labeled").comment("Hello World!")');
+      const config = configure('on("issues.labeled").comment("Hello World!")')
 
       return config.execute(context).catch(() => {
-        expect(github.issues.createComment).toNotHaveBeenCalled();
-      });
-    });
-  });
+        expect(github.issues.createComment).toNotHaveBeenCalled()
+      })
+    })
+  })
 
   describe('filter', () => {
     beforeEach(() => {
-      const labeled = require('./fixtures/webhook/issues.labeled.json');
+      const labeled = require('./fixtures/webhook/issues.labeled.json')
 
-      const event = {event: 'issues', payload: labeled, issue: {}};
-      context = new Context(github, event);
-    });
+      const event = {event: 'issues', payload: labeled, issue: {}}
+      context = new Context(github, event)
+    })
 
     it('calls action when condition matches', () => {
-      const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "bug").close()');
+      const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "bug").close()')
       return config.execute(context).then(() => {
-        expect(github.issues.edit).toHaveBeenCalled();
-      });
-    });
+        expect(github.issues.edit).toHaveBeenCalled()
+      })
+    })
 
     it('does not call action when conditions do not match', () => {
-      const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "foobar").close()');
+      const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "foobar").close()')
 
       return config.execute(context).catch(() => {
-        expect(github.issues.edit).toNotHaveBeenCalled();
-      });
-    });
-  });
+        expect(github.issues.edit).toNotHaveBeenCalled()
+      })
+    })
+  })
 
   describe('include', () => {
-    let content;
+    let content
 
     beforeEach(() => {
-      content = require('./fixtures/content/probot.json');
+      content = require('./fixtures/content/probot.json')
 
-      content.content = new Buffer('on("issues").comment("Hello!");').toString('base64');
-      github.repos.getContent.andReturn(Promise.resolve(content));
+      content.content = Buffer.from('on("issues").comment("Hello!");').toString('base64')
+      github.repos.getContent.andReturn(Promise.resolve(content))
 
-      context = new Context(github, event);
-    });
+      context = new Context(github, event)
+    })
 
     it('includes a file in the local repository', () => {
-      configure('include(".github/triage.js");');
+      configure('include(".github/triage.js");')
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         path: '.github/triage.js'
-      });
-    });
+      })
+    })
 
     it('executes included rules', done => {
       configure('include(".github/triage.js");').execute().then(() => {
-        expect(github.issues.createComment).toHaveBeenCalled();
-        done();
-      });
-    });
+        expect(github.issues.createComment).toHaveBeenCalled()
+        done()
+      })
+    })
 
     it('includes files relative to included repository', () => {
       github.repos.getContent.andCall(params => {
         if (params.path === 'script-a.js') {
           return Promise.resolve({
-            content: new Buffer('include("script-b.js")').toString('base64')
-          });
+            content: Buffer.from('include("script-b.js")').toString('base64')
+          })
         } else {
-          return Promise.resolve({content: ''});
+          return Promise.resolve({content: ''})
         }
-      });
+      })
 
-      const config = configure('include("other/repo:script-a.js");');
+      const config = configure('include("other/repo:script-a.js");')
 
       return config.execute().then(() => {
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'other',
           repo: 'repo',
           path: 'script-b.js'
-        });
-      });
-    });
-  });
+        })
+      })
+    })
+  })
 
   describe('contents', () => {
     it('gets content from repo', () => {
-      const content = {content: new Buffer('file contents').toString('base64')};
-      github.repos.getContent.andReturn(Promise.resolve(content));
+      const content = {content: Buffer.from('file contents').toString('base64')}
+      github.repos.getContent.andReturn(Promise.resolve(content))
 
       const config = configure(`
         on("issues").comment(contents(".github/ISSUE_REPLY_TEMPLATE"));
-      `);
+      `)
 
       return config.execute().then(() => {
         expect(github.issues.createComment).toHaveBeenCalledWith({
@@ -137,32 +137,32 @@ describe('integration', () => {
           repo: 'test',
           number: event.payload.issue.number,
           body: 'file contents'
-        });
-      });
-    });
+        })
+      })
+    })
 
     it('gets contents relative to included repository', () => {
       github.repos.getContent.andCall(params => {
         if (params.path === 'script-a.js') {
           return Promise.resolve({
-            content: new Buffer(`
+            content: Buffer.from(`
               on("issues").comment(contents("content.md"));
             `).toString('base64')
-          });
+          })
         } else {
-          return Promise.resolve({content: ''});
+          return Promise.resolve({content: ''})
         }
-      });
+      })
 
-      const config = configure('include("other/repo:script-a.js");');
+      const config = configure('include("other/repo:script-a.js");')
 
       return config.execute().then(() => {
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'other',
           repo: 'repo',
           path: 'content.md'
-        });
-      });
-    });
-  });
-});
+        })
+      })
+    })
+  })
+})

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,22 +1,22 @@
-const expect = require('expect');
-const Plugin = require('../lib/plugin');
+const expect = require('expect')
+const Plugin = require('../lib/plugin')
 
 class TestPlugin extends Plugin {
-  foo() {
+  foo () {
 
   }
 }
 
 describe('Plugin', () => {
-  const plugin = new TestPlugin();
+  const plugin = new TestPlugin()
 
   describe('api', () => {
     it('includes methods', () => {
-      expect(plugin.api.indexOf('foo') >= 0).toBe(true);
-    });
+      expect(plugin.api.indexOf('foo') >= 0).toBe(true)
+    })
 
     it('exludes constructor', () => {
-      expect(plugin.api.indexOf('constructor')).toBe(-1);
-    });
-  });
-});
+      expect(plugin.api.indexOf('constructor')).toBe(-1)
+    })
+  })
+})

--- a/test/plugins/filter.js
+++ b/test/plugins/filter.js
@@ -1,130 +1,130 @@
-const expect = require('expect');
-const Filter = require('../../lib/plugins/filter');
+const expect = require('expect')
+const Filter = require('../../lib/plugins/filter')
 
-const createSpy = expect.createSpy;
+const createSpy = expect.createSpy
 
 describe('filter plugin', () => {
-  const event = {};
+  const event = {}
   const context = {
     event,
     halt: createSpy().andReturn(Promise.reject(new Error('halted')))
-  };
+  }
 
-  let filter;
+  let filter
 
   before(() => {
-    filter = new Filter();
-  });
+    filter = new Filter()
+  })
 
   describe('filter', () => {
     it('passes the event and context objects to the supplied function', () => {
-      const fn = createSpy();
-      filter.filter(context, fn);
+      const fn = createSpy()
+      filter.filter(context, fn)
 
-      expect(fn).toHaveBeenCalledWith(event, context);
-    });
+      expect(fn).toHaveBeenCalledWith(event, context)
+    })
 
     it('returns true if the function does', () => {
-      const fn = createSpy().andReturn(true);
+      const fn = createSpy().andReturn(true)
 
-      expect(filter.filter(context, fn)).toBe(true);
-    });
+      expect(filter.filter(context, fn)).toBe(true)
+    })
 
     it('returns a rejected promise if the function returns false', () => {
-      const fn = createSpy().andReturn(false);
+      const fn = createSpy().andReturn(false)
 
       return filter.filter(context, fn).catch(err => {
-        expect(err.message).toEqual('halted');
-      });
-    });
-  });
+        expect(err.message).toEqual('halted')
+      })
+    })
+  })
 
   describe('then', () => {
     it('passes the event and context objects to the supplied function', () => {
-      const fn = createSpy();
-      filter.filter(context, fn);
+      const fn = createSpy()
+      filter.filter(context, fn)
 
-      expect(fn).toHaveBeenCalledWith(event, context);
-    });
+      expect(fn).toHaveBeenCalledWith(event, context)
+    })
 
     it('returns whatever the function does', () => {
-      const fn = createSpy().andReturn('bazinga!');
+      const fn = createSpy().andReturn('bazinga!')
 
-      expect(filter.then(context, fn)).toBe('bazinga!');
-    });
-  });
+      expect(filter.then(context, fn)).toBe('bazinga!')
+    })
+  })
 
   describe('on', () => {
     describe('matching only the event name', () => {
       it('matches on a single event', () => {
-        event.event = 'issues';
+        event.event = 'issues'
 
         return filter.on(context, 'issues').then(result => {
-          expect(result).toEqual('issues');
-        });
-      });
+          expect(result).toEqual('issues')
+        })
+      })
 
       it('fails to match on a single event', () => {
-        event.event = 'issues';
+        event.event = 'issues'
 
         return filter.on(context, 'foo').catch(err => {
-          expect(err.message).toBe('halted');
-        });
-      });
+          expect(err.message).toBe('halted')
+        })
+      })
 
       it('matches any of the event names', () => {
-        event.event = 'foo';
+        event.event = 'foo'
 
         return filter.on(context, 'issues', 'foo').then(result => {
-          expect(result).toEqual('foo');
-        });
-      });
+          expect(result).toEqual('foo')
+        })
+      })
 
       it('fails to match if none of the event names match', () => {
-        event.event = 'bar';
+        event.event = 'bar'
 
         return filter.on(context, 'issues', 'foo').catch(err => {
-          expect(err.message).toBe('halted');
-        });
-      });
-    });
+          expect(err.message).toBe('halted')
+        })
+      })
+    })
 
     describe('matching the event and action', () => {
       it('matches on a single event', () => {
-        event.event = 'issues';
-        event.payload = {action: 'opened'};
+        event.event = 'issues'
+        event.payload = {action: 'opened'}
 
         return filter.on(context, 'issues.opened').then(result => {
-          expect(result).toBe('issues.opened');
-        });
-      });
+          expect(result).toBe('issues.opened')
+        })
+      })
 
       it('fails to match on a single event', () => {
-        event.event = 'issues';
-        event.payload = {action: 'foo'};
+        event.event = 'issues'
+        event.payload = {action: 'foo'}
 
         return filter.on(context, 'issues.opened').catch(err => {
-          expect(err.message).toBe('halted');
-        });
-      });
+          expect(err.message).toBe('halted')
+        })
+      })
 
       it('matches any of the event descriptors', () => {
-        event.event = 'issues';
-        event.payload = {action: 'closed'};
+        event.event = 'issues'
+        event.payload = {action: 'closed'}
 
         return filter.on(context, 'issues.opened', 'issues.closed').then(result => {
-          expect(result).toBe('issues.closed');
-        });
-      });
+          expect(result).toBe('issues.closed')
+        })
+      })
 
       it('fails to match if none of the event descriptors match', () => {
-        event.event = 'issues';
-        event.payload = {action: 'foo'};
+        event.event = 'issues'
+        event.payload = {action: 'foo'}
 
         return filter.on(context, 'issues.opened', 'issues.closed').catch(err => {
-          expect(err.message).toBe('halted');
-        });
-      });
-    });
-  });
-});
+          expect(err.message).toBe('halted')
+        })
+      })
+    })
+  })
+})

--- a/test/plugins/issues.js
+++ b/test/plugins/issues.js
@@ -1,13 +1,13 @@
-const expect = require('expect');
-const Issues = require('../../lib/plugins/issues');
-const Context = require('../../lib/context');
-const payload = require('../fixtures/webhook/comment.created.json');
+const expect = require('expect')
+const Issues = require('../../lib/plugins/issues')
+const Context = require('../../lib/context')
+const payload = require('../fixtures/webhook/comment.created.json')
 
-const createSpy = expect.createSpy;
+const createSpy = expect.createSpy
 
 describe('issues plugin', () => {
-  let context;
-  let github;
+  let context
+  let github
 
   before(() => {
     github = {
@@ -29,216 +29,216 @@ describe('issues plugin', () => {
       pullRequests: {
         deleteComment: createSpy()
       }
-    };
-    context = new Context(github, {payload});
-    this.issues = new Issues();
-  });
+    }
+    context = new Context(github, {payload})
+    this.issues = new Issues()
+  })
 
   describe('locking', () => {
     it('locks', () => {
-      this.issues.lock(context);
+      this.issues.lock(context)
 
       expect(github.issues.lock).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6
-      });
-    });
+      })
+    })
 
     it('unlocks', () => {
-      this.issues.unlock(context);
+      this.issues.unlock(context)
 
       expect(github.issues.unlock).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6
-      });
-    });
-  });
+      })
+    })
+  })
 
   describe('state', () => {
     it('opens an issue', () => {
-      this.issues.open(context);
+      this.issues.open(context)
 
       expect(github.issues.edit).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         state: 'open'
-      });
-    });
+      })
+    })
     it('closes an issue', () => {
-      this.issues.close(context);
+      this.issues.close(context)
 
       expect(github.issues.edit).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         state: 'closed'
-      });
-    });
-  });
+      })
+    })
+  })
 
   describe('labels', () => {
     it('adds a label', () => {
-      this.issues.label(context, 'hello');
+      this.issues.label(context, 'hello')
 
       expect(github.issues.addLabels).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         body: ['hello']
-      });
-    });
+      })
+    })
 
     it('adds multiple labels', () => {
-      this.issues.label(context, 'hello', 'world');
+      this.issues.label(context, 'hello', 'world')
 
       expect(github.issues.addLabels).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         body: ['hello', 'world']
-      });
-    });
+      })
+    })
 
     it('removes a single label', () => {
-      this.issues.unlabel(context, 'hello');
+      this.issues.unlabel(context, 'hello')
 
       expect(github.issues.removeLabel).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         name: 'hello'
-      });
-    });
+      })
+    })
 
     it('removes a multiple labels', () => {
-      this.issues.unlabel(context, 'hello', 'goodbye');
+      this.issues.unlabel(context, 'hello', 'goodbye')
 
       expect(github.issues.removeLabel).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         name: 'hello'
-      });
+      })
 
       expect(github.issues.removeLabel).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         name: 'goodbye'
-      });
-    });
-  });
+      })
+    })
+  })
 
   describe('comments', () => {
     it('creates a comment', () => {
-      this.issues.comment(context, 'Hello world!');
+      this.issues.comment(context, 'Hello world!')
 
       expect(github.issues.createComment).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         body: 'Hello world!'
-      });
-    });
+      })
+    })
 
     it('evaluates templates with handlebars', () => {
-      this.issues.comment(context, 'Hello @{{ sender.login }}!');
+      this.issues.comment(context, 'Hello @{{ sender.login }}!')
 
       expect(github.issues.createComment).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         body: 'Hello @bkeepers!'
-      });
-    });
-  });
+      })
+    })
+  })
 
   describe('assignment', () => {
     it('assigns a user', () => {
-      this.issues.assign(context, 'bkeepers');
+      this.issues.assign(context, 'bkeepers')
 
       expect(github.issues.addAssigneesToIssue).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         assignees: ['bkeepers']
-      });
-    });
+      })
+    })
 
     it('assigns multiple users', () => {
-      this.issues.assign(context, 'hello', 'world');
+      this.issues.assign(context, 'hello', 'world')
 
       expect(github.issues.addAssigneesToIssue).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         assignees: ['hello', 'world']
-      });
-    });
+      })
+    })
 
     it('unassigns a user', () => {
-      this.issues.unassign(context, 'bkeepers');
+      this.issues.unassign(context, 'bkeepers')
 
       expect(github.issues.removeAssigneesFromIssue).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         body: {assignees: ['bkeepers']}
-      });
-    });
+      })
+    })
 
     it('unassigns multiple users', () => {
-      this.issues.unassign(context, 'hello', 'world');
+      this.issues.unassign(context, 'hello', 'world')
 
       expect(github.issues.removeAssigneesFromIssue).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         number: 6,
         body: {assignees: ['hello', 'world']}
-      });
-    });
-  });
+      })
+    })
+  })
 
   describe('deleteComment', () => {
     it('deletes an issue comment', () => {
-      this.issues.deleteComment(context);
+      this.issues.deleteComment(context)
 
       expect(github.issues.deleteComment).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         id: 252508381
-      });
-    });
+      })
+    })
 
     it('deletes a commit comment', () => {
-      const payload = require('../fixtures/webhook/commit_comment.created');
+      const payload = require('../fixtures/webhook/commit_comment.created')
 
-      context = new Context(github, {payload});
-      this.issues.deleteComment(context);
+      context = new Context(github, {payload})
+      this.issues.deleteComment(context)
 
       expect(github.repos.deleteCommitComment).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         id: 20067099
-      });
-    });
+      })
+    })
 
     it('deletes a PR comment', () => {
-      const payload = require('../fixtures/webhook/pull_request_review_comment.created');
+      const payload = require('../fixtures/webhook/pull_request_review_comment.created')
 
-      context = new Context(github, {payload});
-      this.issues.deleteComment(context);
+      context = new Context(github, {payload})
+      this.issues.deleteComment(context)
 
       expect(github.pullRequests.deleteComment).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
         id: 90805181
-      });
-    });
-  });
+      })
+    })
+  })
 
   describe('createIssue', () => {
     it('creates an issue', () => {
@@ -250,9 +250,9 @@ describe('issues plugin', () => {
           body: 'body',
           assignees: undefined,
           labels: undefined
-        });
-      });
-    });
+        })
+      })
+    })
 
     it('resolves body content', () => {
       return this.issues.createIssue(context, {title: 'testing', body: Promise.resolve('body')}).then(() => {
@@ -263,9 +263,9 @@ describe('issues plugin', () => {
           body: 'body',
           assignees: undefined,
           labels: undefined
-        });
-      });
-    });
+        })
+      })
+    })
 
     it('sets optional parameters', () => {
       return this.issues.createIssue(context, {title: 'testing', body: 'body', assignees: ['bkeepers'], labels: ['hello']}).then(() => {
@@ -276,8 +276,8 @@ describe('issues plugin', () => {
           body: 'body',
           assignees: ['bkeepers'],
           labels: ['hello']
-        });
-      });
-    });
-  });
-});
+        })
+      })
+    })
+  })
+})

--- a/test/plugins/projects.js
+++ b/test/plugins/projects.js
@@ -1,13 +1,13 @@
-const expect = require('expect');
-const Projects = require('../../lib/plugins/projects');
-const Context = require('../../lib/context');
-const payload = require('../fixtures/webhook/issue.created.json');
+const expect = require('expect')
+const Projects = require('../../lib/plugins/projects')
+const Context = require('../../lib/context')
+const payload = require('../fixtures/webhook/issue.created.json')
 
-const createSpy = expect.createSpy;
+const createSpy = expect.createSpy
 
 describe('projects plugin', () => {
-  let context;
-  let github;
+  let context
+  let github
 
   before(() => {
     github = {
@@ -16,19 +16,19 @@ describe('projects plugin', () => {
         getProjectColumns: createSpy(),
         getRepoProjects: createSpy()
       }
-    };
-    context = new Context(github, {payload});
-    this.projects = new Projects();
-  });
+    }
+    context = new Context(github, {payload})
+    this.projects = new Projects()
+  })
 
   describe('createCard', () => {
     it('creates a project card', () => {
-      this.projects.createCard(context, {project:'myProject', column:'New'}).then(() => {
+      this.projects.createCard(context, {project: 'myProject', column: 'New'}).then(() => {
         expect(github.projects.getRepoProjects).toHaveBeenCalledWith({
           owner: 'pholleran',
           repo: 'test'
-        });
-      });
-    });
-  });
-});
+        })
+      })
+    })
+  })
+})

--- a/test/util/github-url.js
+++ b/test/util/github-url.js
@@ -1,5 +1,5 @@
-const expect = require('expect');
-const url = require('../../lib/util/github-url');
+const expect = require('expect')
+const url = require('../../lib/util/github-url')
 
 describe('github-url', () => {
   const cases = {
@@ -8,11 +8,11 @@ describe('github-url', () => {
     'owner/repo:path/to/file.js': {owner: 'owner', repo: 'repo', path: 'path/to/file.js'},
     'path.js#ref': {path: 'path.js', ref: 'ref'},
     'owner/repo:path.js#ref': {owner: 'owner', repo: 'repo', path: 'path.js', ref: 'ref'}
-  };
+  }
 
   Object.keys(cases).forEach(path => {
     it(path, () => {
-      expect(url(path)).toEqual(cases[path]);
-    });
-  });
-});
+      expect(url(path)).toEqual(cases[path])
+    })
+  })
+})

--- a/test/workflow.js
+++ b/test/workflow.js
@@ -1,115 +1,115 @@
-const expect = require('expect');
-const Plugin = require('../lib/plugin');
-const Workflow = require('../lib/workflow');
+const expect = require('expect')
+const Plugin = require('../lib/plugin')
+const Workflow = require('../lib/workflow')
 
 class TestPlugin extends Plugin {
-  doSomething(context, name, value) {
-    context[name] = value;
+  doSomething (context, name, value) {
+    context[name] = value
   }
 
-  rejectPromise() {
-    return Promise.reject(new Error('HALT AND CATCH FIRE!!!'));
+  rejectPromise () {
+    return Promise.reject(new Error('HALT AND CATCH FIRE!!!'))
   }
 
-  returnUndefined() {
-    return undefined;
+  returnUndefined () {
+    return undefined
   }
 
-  test() {
-    return 'passed!';
+  test () {
+    return 'passed!'
   }
 
-  throwError() {
-    throw new Error('Nothing to see here, move along');
+  throwError () {
+    throw new Error('Nothing to see here, move along')
   }
 }
 
 describe('Workflow', () => {
-  let context;
-  let workflow;
+  let context
+  let workflow
 
   beforeEach(() => {
-    context = {};
-    workflow = new Workflow([new TestPlugin()]);
-  });
+    context = {}
+    workflow = new Workflow([new TestPlugin()])
+  })
 
   describe('construction', () => {
     it('adds the plugins distinctiveness to its own', () => {
-      expect(workflow.api.test).toExist();
-    });
+      expect(workflow.api.test).toExist()
+    })
 
     it('returns a reference to the API for chaining when the test function is called', () => {
-      const api = workflow.api.test();
+      const api = workflow.api.test()
 
-      expect(api).toBe(workflow.api);
-    });
-  });
+      expect(api).toBe(workflow.api)
+    })
+  })
 
   describe('execution', () => {
     it('returns a resolved promise with the ultimate value when everything works', () => {
-      workflow.api.test();
+      workflow.api.test()
 
       return workflow.execute(context).then(result => {
-        expect(result).toBe('passed!');
-      });
-    });
+        expect(result).toBe('passed!')
+      })
+    })
 
     it('returns a rejected promise when a promise is rejected', () => {
-      workflow.api.rejectPromise();
+      workflow.api.rejectPromise()
 
       return workflow.execute(context).catch(err => {
-        expect(err.message).toBe('HALT AND CATCH FIRE!!!');
-      });
-    });
+        expect(err.message).toBe('HALT AND CATCH FIRE!!!')
+      })
+    })
 
     it('returns a rejected promise when an error is thrown', () => {
-      workflow.api.throwError();
+      workflow.api.throwError()
 
       return workflow.execute(context).catch(err => {
-        expect(err.message).toBe('Nothing to see here, move along');
-      });
-    });
+        expect(err.message).toBe('Nothing to see here, move along')
+      })
+    })
 
     it('calls each chained function when things succeed', () => {
-      workflow.api.doSomething('bar', 'baz').doSomething('baz', 'quux');
+      workflow.api.doSomething('bar', 'baz').doSomething('baz', 'quux')
 
       return workflow.execute(context).then(() => {
-        expect(context.bar).toBe('baz');
-        expect(context.baz).toBe('quux');
-      });
-    });
+        expect(context.bar).toBe('baz')
+        expect(context.baz).toBe('quux')
+      })
+    })
 
     it('calls each chained function even if a falsy value is returned', () => {
-      workflow.api.doSomething('bar', 'baz').returnUndefined().doSomething('baz', 'quux');
+      workflow.api.doSomething('bar', 'baz').returnUndefined().doSomething('baz', 'quux')
 
       return workflow.execute(context).then(() => {
-        expect(context.bar).toBe('baz');
-        expect(context.baz).toBe('quux');
-      });
-    });
+        expect(context.bar).toBe('baz')
+        expect(context.baz).toBe('quux')
+      })
+    })
 
     it('calls each chained function until a promise is rejected', () => {
-      workflow.api.doSomething('bar', 'baz').rejectPromise().doSomething('baz', 'quux');
+      workflow.api.doSomething('bar', 'baz').rejectPromise().doSomething('baz', 'quux')
 
       return workflow.execute(context).then(() => {
-        throw new Error('Should not happen');
+        throw new Error('Should not happen')
       }, err => {
-        expect(err.message).toBe('HALT AND CATCH FIRE!!!');
-        expect(context.bar).toBe('baz');
-        expect(context.baz).toNotExist();
-      });
-    });
+        expect(err.message).toBe('HALT AND CATCH FIRE!!!')
+        expect(context.bar).toBe('baz')
+        expect(context.baz).toNotExist()
+      })
+    })
 
     it('calls each chained function until an error is thrown', () => {
-      workflow.api.doSomething('bar', 'baz').throwError().doSomething('baz', 'quux');
+      workflow.api.doSomething('bar', 'baz').throwError().doSomething('baz', 'quux')
 
       return workflow.execute(context).then(() => {
-        throw new Error('Should not happen');
+        throw new Error('Should not happen')
       }, err => {
-        expect(err.message).toBe('Nothing to see here, move along');
-        expect(context.bar).toBe('baz');
-        expect(context.baz).toNotExist();
-      });
-    });
-  });
-});
+        expect(err.message).toBe('Nothing to see here, move along')
+        expect(context.bar).toBe('baz')
+        expect(context.baz).toNotExist()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Switch linter form `xo` to `standard` to follow probot community move.
All changes are only from `standard --fix`.

I'm not sure this is relevant here, but I would prefer to ask the question _before_ updating `probot`.